### PR TITLE
add --account param to amz_stream_cli commands

### DIFF
--- a/amz_stream_cli/cli.py
+++ b/amz_stream_cli/cli.py
@@ -68,7 +68,8 @@ def create_subscription(
     create_subscription_dict = {
         "destinationArn": destination_arn,
         "clientRequestToken": client_request_token,
-        "dataSetId": data_set_id.value
+        "dataSetId": data_set_id.value,
+        "accountId": account.value,
     }
     if notes is not None:
         create_subscription_dict["notes"] = notes

--- a/amz_stream_cli/cli.py
+++ b/amz_stream_cli/cli.py
@@ -57,12 +57,13 @@ def _check_for_error_message_from_api(payload: dict) -> None:
              --notes "This is a marketing stream subscription"
              """)
 def create_subscription(
-        api_region: AdvertisingApiRegion = typer.Option(AdvertisingApiRegion.NA, "--api-region", "-a", help="Advertising API region to use. Default is NA."),
+        api_region: AdvertisingApiRegion = typer.Option(AdvertisingApiRegion.NA, "--api-region", "-r", help="Advertising API region to use. Default is NA."),
         destination_arn: str = typer.Option(..., "--destination-arn", "-e", help="AWS ARN of the destination endpoint associated with the subscription. Supported destination types: SQS"),
         client_request_token: str = typer.Option(..., "--client-request-token", "-c", help="Unique value supplied by the caller used to track identical API requests. Should request be re-tried, "
                                                                                       "the caller should supply the same value."),
         notes: str = typer.Option(None, "--notes", "-n", help="Additional details associated with the subscription."),
-        data_set_id: DataSet = typer.Option(..., "--data-set-id", "-d", help="DataSet ID to use for the subscription.")
+        data_set_id: DataSet = typer.Option(..., "--data-set-id", "-d", help="DataSet ID to use for the subscription."),
+        account: str = typer.Option("default", "--account", "-a", help="Amazon Advertising API Account profile.")
 ) -> None:
     create_subscription_dict = {
         "destinationArn": destination_arn,
@@ -72,7 +73,7 @@ def create_subscription(
     if notes is not None:
         create_subscription_dict["notes"] = notes
 
-    response = Stream(marketplace=AdvertisingApiRegion.get_marketplace(api_region)) \
+    response = Stream(account=account, marketplace=AdvertisingApiRegion.get_marketplace(api_region)) \
         .create_subscription(body=json.dumps(create_subscription_dict))
     _check_for_error_message_from_api(response.payload)
     table = _subscription_to_table(response.payload)
@@ -90,10 +91,11 @@ def create_subscription(
              --notes "Subscription archived from CLI tool" 
              """)
 def update_subscription(
-        api_region: AdvertisingApiRegion = typer.Option(AdvertisingApiRegion.NA, "--api-region", "-a", help="Advertising API region to use. Default is NA."),
+        api_region: AdvertisingApiRegion = typer.Option(AdvertisingApiRegion.NA, "--api-region", "-r", help="Advertising API region to use. Default is NA."),
         subscription_id: str = typer.Option(..., "--subscription-id", "-s", help="Subscription ID of the subscription that will be updated."),
         status: SubscriptionUpdateEntityStatus = typer.Option(..., "--status", "-t", help="Status to use for the subscription."),
         notes: str = typer.Option(None, "--notes", "-n", help="Notes for the subscription update."),
+        account: str = typer.Option("default", "--account", "-a", help="Amazon Advertising API Account profile.")
 ) -> None:
     update_subscription_dict = {
         "status": status.value
@@ -101,7 +103,7 @@ def update_subscription(
     if notes is not None:
         update_subscription_dict["notes"] = notes
 
-    response = Stream(marketplace=AdvertisingApiRegion.get_marketplace(api_region)) \
+    response = Stream(account=account, marketplace=AdvertisingApiRegion.get_marketplace(api_region)) \
         .update_subscription(subscription_id=subscription_id, body=json.dumps(update_subscription_dict))
 
     _check_for_error_message_from_api(response.payload)
@@ -116,10 +118,11 @@ def update_subscription(
              --subscription-id amzn1.fead.xxxx.xxxxxxxxxxxx 
              """)
 def get_subscription(
-        api_region: AdvertisingApiRegion = typer.Option(AdvertisingApiRegion.NA, "--api-region", "-a", help="Advertising API region to use. Default is NA."),
+        api_region: AdvertisingApiRegion = typer.Option(AdvertisingApiRegion.NA, "--api-region", "-r", help="Advertising API region to use. Default is NA."),
         subscription_id: str = typer.Option(..., "--subscription-id", "-s", help="Subscription ID of the subscription to be fetched."),
+        account: str = typer.Option("default", "--account", "-a", help="Amazon Advertising API Account profile."),
 ) -> None:
-    response = Stream(marketplace=AdvertisingApiRegion.get_marketplace(api_region)) \
+    response = Stream(account=account, marketplace=AdvertisingApiRegion.get_marketplace(api_region)) \
         .get_subscription(subscription_id=subscription_id)
     _check_for_error_message_from_api(response.payload)
     subscription = response.payload['subscription']
@@ -134,9 +137,10 @@ def get_subscription(
              python -m amz_stream_cli list \n
              """)
 def list_subscriptions(
-        api_region: AdvertisingApiRegion = typer.Option(AdvertisingApiRegion.NA, "--api-region", "-a", help="Advertising API region to use. Default is NA.")
+        api_region: AdvertisingApiRegion = typer.Option(AdvertisingApiRegion.NA, "--api-region", "-r", help="Advertising API region to use. Default is NA."),
+        account: str = typer.Option("default", "--account", "-a", help="Amazon Advertising API Account profile.")
 ) -> None:
-    response = Stream(marketplace=AdvertisingApiRegion.get_marketplace(api_region)).list_subscriptions()
+    response = Stream(account=account, marketplace=AdvertisingApiRegion.get_marketplace(api_region)).list_subscriptions()
     _check_for_error_message_from_api(response.payload)
     if 'subscriptions' in response.payload:
         subscriptions = sorted(response.payload['subscriptions'], key=lambda d: d['status'])

--- a/amz_stream_infra/stack_definitions.py
+++ b/amz_stream_infra/stack_definitions.py
@@ -263,6 +263,7 @@ class AmzStreamConsumerStack(Stack):
         self.subscription_confirmation.subscribe_to_fanout(self.stream_fanout)
 
         Tags.of(self).add("data_set_id", dataset_config['dataSetId'])
+        Tags.of(self).add("account_id", dataset_config['accountId'])
 
 
 

--- a/amz_stream_infra/stack_definitions.py
+++ b/amz_stream_infra/stack_definitions.py
@@ -263,7 +263,5 @@ class AmzStreamConsumerStack(Stack):
         self.subscription_confirmation.subscribe_to_fanout(self.stream_fanout)
 
         Tags.of(self).add("data_set_id", dataset_config['dataSetId'])
-        Tags.of(self).add("account_id", dataset_config['accountId'])
-
-
-
+        if dataset_config.get('accountId'):
+            Tags.of(self).add("account_id", dataset_config['accountId'])


### PR DESCRIPTION
The Stream use the default advertising account, but if we have several accounts/profiles an account param helps a lot.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
